### PR TITLE
chore: replace Git dependencies

### DIFF
--- a/Assets/Root/package.json
+++ b/Assets/Root/package.json
@@ -7,9 +7,9 @@
   "author": "yenmoc <phongsoyenmoc.diep@gmail.com> (https://github.com/phongsoyenmoc)",
   "license": "MIT",
   "dependencies": {
-    "com.worldreaver.naughtyattributes": "ssh://git@github.com/worldreaver/NaughtyAttributes#1.2.0",
-    "com.worldreaver.unitask": "ssh://git@github.com/worldreaver/UniTask#1.4.0",
-    "com.worldreaver.utility": "ssh://git@github.com/worldreaver/Utility#1.3.1"
+    "com.dbrizov.naughtyattributes": "2.0.4",
+    "com.cysharp.unitask": "1.3.1",
+    "com.worldreaver.utility": "1.3.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Refs #1, replaced Git dependencies, also changed back to original UPM packages.

To use this, merge and bump a version release, then you can install the package with:
```
openupm add com.worldreaver.flatdata
```